### PR TITLE
Fix decoding and blurring issue for scaled or old (3.3.5) UI

### DIFF
--- a/IPC.lua
+++ b/IPC.lua
@@ -4,7 +4,7 @@ counter = 0
 prevZone = ""
 prevSubZone = ""
 message = ""
-local width = 1
+local width = 3 -- Don't change to less than 3
 local height = 1
 
 function loop()
@@ -25,11 +25,20 @@ function IPC_CreateFrames()
 
     for i=1, frame_count do
         frames[i] = CreateFrame("Frame", nil, UIParent)
-        frames[i]:SetFrameStrata("TOOLTIP")
+        -- Make it independent of UI Scale
+        if math.abs(frames[i]:GetEffectiveScale() - 1) > 0.01 then -- Frame is not full size
+            frames[i]:SetScale(1 / frames[i]:GetParent():GetEffectiveScale()) -- Rescale the frame to be full size
+        end
+        -- Alternation of frame strata helps to reduce amount of blur between frames
+        if i % 2 == 0 then
+            frames[i]:SetFrameStrata("TOOLTIP")
+        else
+            frames[i]:SetFrameStrata("FULLSCREEN_DIALOG")
+        end
         frames[i]:SetWidth(width)
         frames[i]:SetHeight(height)
 
-        -- initialise it as black
+        -- Initialise it as black
         local t = frames[i]:CreateTexture(nil, "TOOLTIP")
         t:SetTexture(0, 0, 0, 0)
         t:SetAllPoints(frames[i])
@@ -79,15 +88,9 @@ function IPC_PaintSomething(text)
         if #trio > 1 then g = string.byte(trio:sub(2,2)) end
         if #trio > 2 then b = string.byte(trio:sub(3,3)) end
         squares_painted = squares_painted + 1
-        IPC_PaintFrame(frames[squares_painted*2-1], r, g, b)
+        IPC_PaintFrame(frames[squares_painted], r, g, b)
     end
-    squares_painted = 0
-    for _ in text:gmatch".?.?.?" do
-        squares_painted = squares_painted + 1
-        IPC_PaintFrame(frames[squares_painted*2], 0, 0, 0, 1)
-    end
-    -- and then paint the last one white
-    IPC_PaintFrame(frames[squares_painted*2-2], 255, 255, 255, 1)
+    IPC_PaintFrame(frames[squares_painted], 255, 255, 255, 1)
 end
 
 function IPC_EncodeMessage()

--- a/IPC.toc
+++ b/IPC.toc
@@ -1,7 +1,7 @@
 ## Interface: 50400
 ## Title: IPC
 ## Author: AipNooBest
-## Version: v1.2.0
+## Version: v1.3.0
 ## Notes: Encodes player information into colorful array at the top of your screen for Discord Rich Presence.
 local.lua
 IPC.xml

--- a/local.lua
+++ b/local.lua
@@ -3,4 +3,4 @@ playerOnBattleGround = "In battleground"
 playerIsDead = " (Dead)"
 itemLevelStr = " item level"
 function inGroupOfSomePeople()
-    return "In group of " .. GetNumGroupMembers() .. " people" end -- Use GetNumPartyMembers()+1 [didn't test yet for +1 thing] for <5.0.4
+    return "In group of " .. GetNumPartyMembers()+1 .. " people" end

--- a/local.lua
+++ b/local.lua
@@ -3,4 +3,4 @@ playerOnBattleGround = "In battleground"
 playerIsDead = " (Dead)"
 itemLevelStr = " item level"
 function inGroupOfSomePeople()
-    return "In group of " .. GetNumPartyMembers()+1 .. " people" end
+    return "In group of " .. GetNumGroupMembers() .. " people" end -- Use GetNumPartyMembers()+1 [didn't test yet for +1 thing] for <5.0.4


### PR DESCRIPTION
Fixes #4 and #1.

Versions of WoW before 3.3.5 had a problem with processing frames that stood close to each other, which caused blurring between them, which did not allow normal processing of a multicolored array of data (incorrect colors caused the script to crash and display "In Main Menu"). Moreover, if the user had changed in-game scaling or used scaling in the OS itself, it resulted in incorrect calculation of pixel size, which also caused blurring.

In this Pull Request, I have rewritten the algorithm for reading a multicolored array of data to account for these cases, and I have also added an automatic scale edit for the addon frames themselves to be independent of the player interface scaling. Special thanks to @CheeseKeik for helping me come up with and write the algorithm